### PR TITLE
Updated binary name to kubectl-vaultlogin_{{ .Env.VERSION }}-{{ .Os }…

### DIFF
--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -26,7 +26,7 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-binary: kubectl-vaultlogin_{{ .Version }}-{{ .Os }}-{{ .Arch }}
+binary: kubectl-vaultlogin_{{ .Env.VERSION }}-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:


### PR DESCRIPTION
…}-{{ .Arch }} in .slsa-goreleaser/linux-amd64.yml